### PR TITLE
Hexadecimal notations for colors with opacity replaced by rgba function; Sitemap

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -185,7 +185,7 @@ nav, header, footer, main
 	padding:15px;
 	border-radius: 5px;
 	max-width:280px;
-	background: linear-gradient(to right, #000000dd, #00000055);
+	background: linear-gradient(to right, rgba(0,0,0,0.875), rgba(0,0,0,0.375));
 }
 .packageTitle
 {

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -181,7 +181,7 @@ nav, header, footer, main
 }
 .packageDescription
 {
-	background-color:#000000aa;
+	background-color:rgba(0,0,0,0.6875);
 	padding:15px;
 	border-radius: 5px;
 	max-width:280px;

--- a/about.md
+++ b/about.md
@@ -3,5 +3,6 @@ layout: default
 title: About
 permalink: /about/
 contentdescription: Unfilled about page
+excludeFromSitemap: true
 ---
 

--- a/doc_walkthrough.md
+++ b/doc_walkthrough.md
@@ -5,6 +5,7 @@ permalink: /doc/walkthrough/
 creator: Socialdarwinist; necropotame
 contentdescription: Walkthrough through the editor of TeeUniverse, aimed at beginner mappers
 subject: Teeworlds mapping; Ninslash mapping; InfClass mapping; OpenFNG mapping; DDNet mapping; map layer; tileset; Teeworlds tileset; quadrilateral graphics; quad;
+changefreq: monthly
 ---
 
 The following page is intended to contain instructions for familiarizing users with the interfaces of the various components of the TeeUniverse editor.

--- a/releases.md
+++ b/releases.md
@@ -5,6 +5,7 @@ permalink: /releases/
 type: dataset
 creator: necropotame
 contentdescription: List of the TeeUniverse releases with version history, including links to compressed distributions of their source codes and their binaries
+changefreq: weekly
 ---
 
 {% assign sortedReleases = site.release | sort: 'title' | reverse %}

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: https://teeuniverse.net/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,1 +1,5 @@
-Sitemap: https://teeuniverse.net/sitemap.xml
+---
+permalink: /robots.txt
+excludeFromSitemap: true
+---
+Sitemap: {{site.url}}/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,21 @@
+---
+permalink: /sitemap.xml
+type: dataset
+creator: Socialdarwinist
+excludeFromSitemap: true
+---
+
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+	<url>
+		<loc>{{site.url}}</loc>
+	</url>
+{% for deed in site.pages %}
+{% if deed.permalink != null and deed.excludeFromSitemap != true %}
+	<url>
+		<loc>{{site.url}}{{deed.permalink}}</loc>
+		{% if deed.changefreq != null %}
+		<changefreq>{{deed.changefreq}}</changefreq>
+		{% endif %}
+	</url>{% endif %}{% endfor %}
+</urlset>


### PR DESCRIPTION
Such notation is yet [just in the process of becoming](https://drafts.csswg.org/css-color/#hex-notation) legal, and it is only supported by the Gecko and Webkit layout engines, from those which I know.